### PR TITLE
Alexdlukens/issue13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,3 +64,37 @@ jobs:
           poetry run pytest tests/ -x -vv --junitxml=junit/test-results.xml
         env:
           MONGODB_URI: mongodb://root:secret@localhost:${{ steps.calc.outputs.port }}/?authSource=admin
+  sphinx_docs:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v9
+      - name: Poetry dev dependencies install
+        run: |
+          poetry install --with dev
+      - name: Build and Deploy Documentation
+        run: |
+          TZ=UTC poetry run sphinx-build -b html docs/source/ build/
+          touch build/.nojekyll
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,6 +66,7 @@ jobs:
           MONGODB_URI: mongodb://root:secret@localhost:${{ steps.calc.outputs.port }}/?authSource=admin
   sphinx_docs:
     needs: build
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       pages: write      # to deploy to Pages

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 This repo is intended to be the core event tracking framework that will be built-upon in other applications
 
+**Note:** As of now, this is just a personal project. Any advise or contributions towards the direction of this project would be greatly appreciated. Feel free to make a Github Issue/discussion about future work.
+
+
 ## Overview
 In this context, an event is a "log", as a dictionary with pre-defined fields. These fields are defined in Pydantic models, which validate the event during the logging process.
 

--- a/src/eventit_py/event_logger.py
+++ b/src/eventit_py/event_logger.py
@@ -158,7 +158,9 @@ class EventLogger(BaseEventLogger):
             event.count += 1
 
             # update in db based on uuid
-            response = self.db_client.update_event_by_uuid(group=group, event=event)
+            response = self.db_client.update_event_by_uuid(
+                group=group, event=event, event_type=event_type
+            )
             if response["modified_count"] != 1:
                 raise ValueError(
                     f"failed to update event with uuid {event.uuid} in group {group}"

--- a/src/eventit_py/logging_backends.py
+++ b/src/eventit_py/logging_backends.py
@@ -129,6 +129,21 @@ class BaseLoggingClient:
             "get_event_by_uuid method must be implemented in derived classes"
         )
 
+    def update_event_by_uuid(self, group: str, event: BaseEvent) -> dict[str, int]:
+        """
+        Update an event by its UUID. Retrieves UUID from event object.
+
+        Args:
+            group (str): The group to update the event in.
+            event (BaseModel): The updated event to store.
+
+        Returns:
+            None
+        """
+        raise NotImplementedError(
+            "update_event_by_uuid method must be implemented in derived classes"
+        )
+
 
 class FileLoggingClient(BaseLoggingClient):
     """Append to files from provided filepath for logging"""
@@ -533,3 +548,26 @@ class MongoDBLoggingClient(BaseLoggingClient):
         if len(found_event) == 0:
             return None
         return found_event[0]
+
+    def update_event_by_uuid(self, group: str, event: BaseEvent) -> dict[str, int]:
+        """
+        Update an event by its UUID.
+
+        Args:
+            uuid (str): The UUID of the event to update.
+            group (str): The group to update the event in.
+            event (BaseModel): The updated event to store.
+
+        Returns:
+            None
+        """
+        update_response = self._db[group].update_one(
+            {"uuid": str(event.uuid)},
+            {"$set": event.model_dump(exclude_none=self.exclude_none)},
+        )
+
+        response_obj = {
+            "matched_count": update_response.matched_count,
+            "modified_count": update_response.modified_count,
+        }
+        return response_obj

--- a/src/eventit_py/logging_backends.py
+++ b/src/eventit_py/logging_backends.py
@@ -354,12 +354,6 @@ class MongoDBLoggingClient(BaseLoggingClient):
         exclude_none (bool, optional): Whether to exclude None values when logging. Defaults to True.
         database_name (str, optional): The name of the MongoDB database to use. If not provided, a default name will be used.
 
-    Methods:
-        __init__: Initializes the MongoDBLoggingClient instance.
-        reset_db: Resets the database by dropping the current database from MongoDB.
-        log_message: Logs a message into MongoDB.
-        search_events_by_timestamp: Search events within a specified time range for a specific group and event type.
-
     """
 
     def __init__(

--- a/src/eventit_py/pydantic_events.py
+++ b/src/eventit_py/pydantic_events.py
@@ -8,7 +8,6 @@ from pydantic import (
     AwareDatetime,
     BaseModel,
     Field,
-    field_serializer,
     field_validator,
 )
 
@@ -79,10 +78,6 @@ class BaseEvent(BaseModel):
         return value.astimezone(datetime.timezone.utc).replace(
             microsecond=int(value.microsecond / 1000) * 1000
         )
-
-    @field_serializer("uuid")
-    def serialize_uuid(self, value: UUID4, _info):
-        return str(value)
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"BaseEvent(timestamp={self.timestamp.isoformat()}, description={self.description})"

--- a/src/eventit_py/pydantic_events.py
+++ b/src/eventit_py/pydantic_events.py
@@ -30,6 +30,18 @@ def _handle_timestamp(*args, **kwargs):
     return value.replace(microsecond=int(value.microsecond / 1000) * 1000)
 
 
+def _subtract_time_delta(
+    time_obj: datetime.datetime, delta: datetime.timedelta
+) -> tuple[datetime.datetime, datetime.timedelta]:
+    seconds = int(time_obj.timestamp())
+    remainder = datetime.timedelta(
+        seconds=seconds % delta.total_seconds(),
+        microseconds=time_obj.microsecond,
+    )
+    quotient = time_obj - remainder
+    return quotient, remainder
+
+
 class BaseEvent(BaseModel):
     """
     Base class to be used for event tracking. Can be specialized for specific applications
@@ -77,3 +89,23 @@ class BaseEvent(BaseModel):
 
     def __str__(self) -> str:  # pragma: no cover
         return str(self.model_dump_json())
+
+
+class BaseCountableEvent(BaseEvent):
+    """
+    Represents a countable event with a time window and number of events.
+
+    Attributes:
+        time_window (int): Time window in seconds.
+        count (int): Number of events in the time window.
+    """
+
+    time_window: int = Field(default=15, description="Time window in seconds")
+    count: int = Field(default=1, description="Number of events in the time window")
+
+    @field_validator("time_window")  # ensure that the time window is greater than 0
+    @classmethod
+    def validate_time_window(cls, value: float):
+        if value <= 0:
+            raise ValueError("Time window must be greater than 0")
+        return value

--- a/tests/test_countable_events.py
+++ b/tests/test_countable_events.py
@@ -1,0 +1,108 @@
+import datetime
+import time
+
+from bson.codec_options import CodecOptions
+from eventit_py.event_logger import EventLogger
+from eventit_py.pydantic_events import (
+    BaseCountableEvent,
+    _handle_timestamp,
+    _subtract_time_delta,
+)
+from pymongo import MongoClient
+
+EVENTIT_DB_NAME = "eventit"
+
+
+# create class derived from BaseCountableEvent called TenSecondCounter
+class TenSecondCounter(BaseCountableEvent):
+    time_window: int = 10
+
+
+def test_ten_second_counter(get_mongo_uri):
+    mongo_client = MongoClient(get_mongo_uri)
+
+    eventit = EventLogger(MONGO_URL=get_mongo_uri, database=EVENTIT_DB_NAME)
+
+    @eventit.event(
+        description="This is a basic test for MongoDB", event_type=TenSecondCounter
+    )
+    def this_is_a_mongodb_test():
+        return -1
+
+    pre_start_time = _handle_timestamp()
+
+    time_window = TenSecondCounter.model_fields["time_window"].default
+    time_window = datetime.timedelta(seconds=time_window)
+    assert time_window.total_seconds() == 10
+
+    _, remainder = _subtract_time_delta(pre_start_time, time_window)
+
+    # wait for remainder to be up
+    sleep_time = time_window - remainder
+
+    assert sleep_time < time_window
+    assert remainder.total_seconds() < 10
+
+    print(f"waiting {sleep_time} for next time window")
+    time.sleep(sleep_time.total_seconds() + 0.1)
+    # now we should be in the next time window
+
+    start_time = _handle_timestamp()
+
+    base_time_window, remainder = _subtract_time_delta(start_time, time_window)
+
+    for i in range(10):
+        this_is_a_mongodb_test()
+        time.sleep(0.1)
+
+    end_time = _handle_timestamp()
+
+    end_time_window, remainder = _subtract_time_delta(end_time, time_window)
+
+    assert base_time_window == end_time_window
+
+    # get event from db corresponding to base_time_window
+    event = (
+        mongo_client[EVENTIT_DB_NAME]["default"]
+        .with_options(CodecOptions(tz_aware=True))
+        .find_one({"timestamp": base_time_window})
+    )
+
+    # check that the event has 10 entries
+    assert event["count"] == 10
+
+    end_time2 = _handle_timestamp()
+    _, remainder = _subtract_time_delta(end_time2, time_window)
+    # wait for remainder to be up AGAIN
+    sleep_time = time_window - remainder
+
+    assert sleep_time < time_window
+    assert remainder.total_seconds() < 10
+
+    print(f"waiting {sleep_time} for next time window")
+    time.sleep(sleep_time.total_seconds() + 0.1)
+
+    end_time3 = _handle_timestamp()
+    second_time_window, _ = _subtract_time_delta(end_time3, time_window)
+    # now we should be in the next time window, ensure that a new time window event is created
+    for i in range(15):
+        this_is_a_mongodb_test()
+        time.sleep(0.1)
+
+    # get event from db corresponding to base_time_window
+    event1 = (
+        mongo_client[EVENTIT_DB_NAME]["default"]
+        .with_options(CodecOptions(tz_aware=True))
+        .find_one({"timestamp": base_time_window})
+    )
+    event2 = (
+        mongo_client[EVENTIT_DB_NAME]["default"]
+        .with_options(CodecOptions(tz_aware=True))
+        .find_one({"timestamp": second_time_window})
+    )
+    print(f"{event1=}, {event2=}, {base_time_window=}, {second_time_window=}")
+    assert event1["count"] == 10
+    assert event2["count"] == 15
+
+    # ensure the event can be validated into Pydantic model
+    TenSecondCounter.model_validate(event)

--- a/tests/test_countable_events.py
+++ b/tests/test_countable_events.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 
+import pytest
 from bson.codec_options import CodecOptions
 from eventit_py.event_logger import EventLogger
 from eventit_py.pydantic_events import (
@@ -18,7 +19,120 @@ class TenSecondCounter(BaseCountableEvent):
     time_window: int = 10
 
 
-def test_ten_second_counter(get_mongo_uri):
+def test_ten_second_counter_filepath():
+    eventit = EventLogger()
+
+    @eventit.event(
+        description="This is a basic test for MongoDB", event_type=TenSecondCounter
+    )
+    def this_is_a_mongodb_test():
+        return -1
+
+    pre_start_time = _handle_timestamp()
+
+    time_window = TenSecondCounter.model_fields["time_window"].default
+    time_window = datetime.timedelta(seconds=time_window)
+    assert time_window.total_seconds() == 10
+
+    _, remainder = _subtract_time_delta(pre_start_time, time_window)
+
+    # wait for remainder to be up
+    sleep_time = time_window - remainder
+
+    assert sleep_time < time_window
+    assert remainder.total_seconds() < 10
+
+    print(f"waiting {sleep_time} for next time window")
+    time.sleep(sleep_time.total_seconds() + 0.1)
+    # now we should be in the next time window
+
+    start_time = _handle_timestamp()
+
+    base_time_window, remainder = _subtract_time_delta(start_time, time_window)
+
+    for i in range(10):
+        this_is_a_mongodb_test()
+        time.sleep(0.1)
+
+    end_time = _handle_timestamp()
+
+    end_time_window, remainder = _subtract_time_delta(end_time, time_window)
+
+    assert base_time_window == end_time_window
+
+    # get event from db corresponding to base_time_window
+    # event = (
+    #     mongo_client[EVENTIT_DB_NAME]["default"]
+    #     .with_options(CodecOptions(tz_aware=True))
+    #     .find_one({"timestamp": base_time_window})
+    # )
+    event: TenSecondCounter = eventit.db_client.search_events_by_timestamp(
+        start_time=base_time_window,
+        end_time=base_time_window,
+        group="default",
+        event_type=TenSecondCounter,
+        limit=1,
+    )
+    assert len(event) == 1
+    event = event[0]
+
+    # check that the event has 10 entries
+    assert event.count == 10
+
+    end_time2 = _handle_timestamp()
+    _, remainder = _subtract_time_delta(end_time2, time_window)
+    # wait for remainder to be up AGAIN
+    sleep_time = time_window - remainder
+
+    assert sleep_time < time_window
+    assert remainder.total_seconds() < 10
+
+    print(f"waiting {sleep_time} for next time window")
+    time.sleep(sleep_time.total_seconds() + 0.1)
+
+    end_time3 = _handle_timestamp()
+    second_time_window, _ = _subtract_time_delta(end_time3, time_window)
+    # now we should be in the next time window, ensure that a new time window event is created
+    for i in range(15):
+        this_is_a_mongodb_test()
+        time.sleep(0.1)
+
+    # get event from db corresponding to base_time_window
+    # event1 = (
+    #     mongo_client[EVENTIT_DB_NAME]["default"]
+    #     .with_options(CodecOptions(tz_aware=True))
+    #     .find_one({"timestamp": base_time_window})
+    # )
+    # event2 = (
+    #     mongo_client[EVENTIT_DB_NAME]["default"]
+    #     .with_options(CodecOptions(tz_aware=True))
+    #     .find_one({"timestamp": second_time_window})
+    # )
+    event1 = eventit.db_client.search_events_by_timestamp(
+        start_time=base_time_window,
+        end_time=base_time_window,
+        group="default",
+        event_type=TenSecondCounter,
+        limit=1,
+    )[0]
+    event2 = eventit.db_client.search_events_by_timestamp(
+        start_time=second_time_window,
+        end_time=second_time_window,
+        group="default",
+        event_type=TenSecondCounter,
+        limit=1,
+    )[0]
+
+    # print(f"{event1=}, {event2=}, {base_time_window=}, {second_time_window=}")
+    assert event1.count == 10
+    assert event2.count == 15
+
+    # ensure the event can be validated into Pydantic model
+    TenSecondCounter.model_validate(event)
+
+
+@pytest.mark.mongodb
+def test_ten_second_counter_mongodb(get_mongo_uri):
     mongo_client = MongoClient(get_mongo_uri)
 
     eventit = EventLogger(MONGO_URL=get_mongo_uri, database=EVENTIT_DB_NAME)


### PR DESCRIPTION
This merge request closes out the base functionality for "countable" events. 

E.g. if we want to track the number of times a web route is called on a Flask server, we can use an eventit_py.pydantic_events.BaseCountableEvent to define a time window, and log the route normally. The counting will be handled internally, updating metrics in the current time window, and creating a new log record for the next time window as necessary. Examples can be seen in the tests/test_countable_events.py testcases